### PR TITLE
name input_powerspec.txt after config file

### DIFF
--- a/src/config_file.hh
+++ b/src/config_file.hh
@@ -161,6 +161,10 @@ public:
       }
 
       items_[in_section + '/' + name] = value;
+
+      size_t lastindex = filename.find_last_of('.');
+      std::string config_basename = filename.substr(0, lastindex);
+      items_["meta/config_basename"] = config_basename;
     }
   }
 
@@ -286,6 +290,12 @@ public:
   template <class T>
   T get_value_safe(std::string const &key, T default_value) const {
     return get_value_safe("", key, default_value);
+  }
+
+  std::string get_path_relative_to_config(std::string const &filename) const {
+    std::string empty_string;
+    const std::string basename = get_value_safe("meta", "config_basename", empty_string);
+    return basename + "_" + filename;
   }
 
   //! dumps all key-value pairs to a std::ostream

--- a/src/convolution_kernel.cc
+++ b/src/convolution_kernel.cc
@@ -177,7 +177,7 @@ public:
 		pnorm_ = ptf->cosmo_params_["pnorm"];
 		kfac_ = 2.0 * M_PI / boxlength_;
 		kmax_ = kfac_ / 2;
-		tfk_ = new TransferFunction_k(type_, ptf_, nspec_, pnorm_);
+		tfk_ = new TransferFunction_k(type_, ptf_, nspec_, pnorm_, cf);
 
 		cparam_.nx = 1;
 		cparam_.ny = 1;

--- a/src/transfer_function.hh
+++ b/src/transfer_function.hh
@@ -163,7 +163,7 @@ public:
 	double pnorm_, sqrtpnorm_;
 	static tf_type type_;
 
-	TransferFunction_k(tf_type type, transfer_function *tf, real_t nspec, real_t pnorm)
+	TransferFunction_k(tf_type type, transfer_function *tf, real_t nspec, real_t pnorm, config_file &cf)
 			: pnorm_(pnorm)
 	{
 		ptf_ = tf;
@@ -171,7 +171,7 @@ public:
 		sqrtpnorm_ = sqrt(pnorm_);
 		type_ = type;
 
-		std::string fname("input_powerspec.txt");
+		std::string fname(cf.get_path_relative_to_config("input_powerspec.txt"));
 		if (type == delta_cdm || type == delta_matter)
 		{
 			std::ofstream ofs(fname.c_str());


### PR DESCRIPTION
trying to backport https://github.com/cosmo-sims/monofonIC/pull/5 to MUSIC

Sadly the filenames of files that are written are spread over more locations without access to the config file in MUSIC. I didn't want to change many functions, so for now only `input_powerspec.txt` is instead stored as `example_input_powerspec.txt`  (assuming `example.conf`) and I will leave this here as a reminder to get back to it in case of a refactor of the other code