### PR TITLE
add the gas properties in SWIFT output plugin

### DIFF
--- a/src/plugins/output_swift.cc
+++ b/src/plugins/output_swift.cc
@@ -715,6 +715,10 @@ public:
     // do not write out densities as we write out displacements
     if (doBaryons)
       massTable[GAS_PARTTYPE] = omega_b * rhoCrit * pow(boxSize * posFac, 3.0) / pow(2, 3 * levelmax_);
+    if (!doublePrec)
+      __write_gas_properties<float>(gh);
+    else
+      __write_gas_properties<double>(gh);
   }
 
   void write_gas_potential(const grid_hierarchy &gh) { /* skip */


### PR DESCRIPTION
add the gas properties in write_gas_density in output_swift.cc， which make the SWIFT format output including gas properties so that SWIFT can directly read in without errors